### PR TITLE
Update dark.qss

### DIFF
--- a/photobooth/gui/Qt5Gui/stylesheets/dark.qss
+++ b/photobooth/gui/Qt5Gui/stylesheets/dark.qss
@@ -192,11 +192,12 @@ QTabBar::tab:selected {
 
 QTabWidget QWidget {
     color: #333333;
+    font-size: 30px;
 }
 
 QCheckBox::indicator {
-    width: 45px;
-    height: 45px;
+    width: 30px;
+    height: 30px;
     background-color: transparent;
     border-style: outset;
     border-width: 2px;


### PR DESCRIPTION
adding some font-size parameters (identical to the pastel.qss) resolves scaling problems on 1024x600 LCD display (bottom push button line with save/restore defaults/cancel is not visible