### PR TITLE
Smoother image scaling with BICUBIC

### DIFF
--- a/photobooth/camera/__init__.py
+++ b/photobooth/camera/__init__.py
@@ -167,7 +167,7 @@ class Camera:
         picture = self._template.copy()
         for i in range(self._pic_dims.totalNumPictures):
             shot = Image.open(self._pictures[i])
-            resized = shot.resize(self._pic_dims.thumbnailSize)
+            resized = shot.resize(self._pic_dims.thumbnailSize, Image.BICUBIC)
             picture.paste(resized, self._pic_dims.thumbnailOffset[i])
 
         byte_data = BytesIO()


### PR DESCRIPTION
Switched to bicubic scaling, to have smoother images after resize operation.
When scaling pictures, by default the nearest pixel is taken, which can lead to aliasing. BICUBIC gives nicer results, but may result in higher processor load.
https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-filters