### PR TITLE
exclude vscode and PyCharm directories in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ print_*.pdf
 20??-??-??
 build
 dist
-
+.idea/
+.vscode/


### PR DESCRIPTION
Just as a proposal: the .gitignore could also exclude the folders that are typical for Visual Studio Code and PyCharm. (An alternative would be the output of [gitignore.io](https://www.gitignore.io/).