### PR TITLE
Add EOS 450D configuration file

### DIFF
--- a/photobooth/camera/models/canoneos450d.cfg
+++ b/photobooth/camera/models/canoneos450d.cfg
@@ -1,0 +1,15 @@
+[Startup]
+imageformat = Large Fine JPEG
+imageformatsd = Large Fine JPEG
+autopoweroff = 0
+
+[Shutdown]
+imageformat = RAW
+imageformatsd = RAW
+autopoweroff = 30
+
+[Idle]
+output = Off
+
+[Active]
+output = PC


### PR DESCRIPTION
Add missing configuration file for Canon EOS 450D. Basically, it's a copy of the EOS500D config file. Without it, the flash does not fire.