### PR TITLE
[Feature] different directories

### DIFF
--- a/photobooth/defaults.cfg
+++ b/photobooth/defaults.cfg
@@ -13,7 +13,7 @@ hide_cursor = False
 style = default
 
 [Camera]
-# Camera module to use (python-gphoto2, gphoto2-cffi, gphoto2-commandline, 
+# Camera module to use (python-gphoto2, gphoto2-cffi, gphoto2-commandline,
 # opencv, picamera, dummy)
 module = python-gphoto2
 # Specify rotation of camera in degree (possible values: 0, 90, 180, 270)
@@ -92,6 +92,10 @@ basedir = %Y-%m-%d
 basename = photobooth
 # Keep single pictures (True/False)
 keep_pictures = False
+# Extra directory for single pictures (True/False)
+single_extra = False
+# Path for single pictures (if single_extra is True)
+basedir_single = %Y-%m-%d-single
 
 [Mailer]
 # Enable/disable mailer

--- a/photobooth/gui/Qt5Gui/Frames.py
+++ b/photobooth/gui/Qt5Gui/Frames.py
@@ -746,23 +746,45 @@ class Settings(QtWidgets.QFrame):
         keep_pictures.setChecked(self._cfg.getBool('Storage', 'keep_pictures'))
         self.add('Storage', 'keep_pictures', keep_pictures)
 
-        def directory_dialog():
+        single_extra = QtWidgets.QCheckBox()
+        single_extra.setChecked(self._cfg.getBool('Storage', 'single_extra'))
+        self.add('Storage', 'single_extra', single_extra)
+
+        basedir_single = QtWidgets.QLineEdit(self._cfg.get('Storage', 'basedir_single'))
+        self.add('Storage', 'basedir_single', basedir_single)
+
+        def directory_dialog(target):
             dialog = QtWidgets.QFileDialog.getExistingDirectory
-            basedir.setText(dialog(self, _('Select directory'),
+            target.setText(dialog(self, _('Select directory'),
                                    os.path.expanduser('~'),
                                    QtWidgets.QFileDialog.ShowDirsOnly))
 
+        def directory_dialog_basedir():
+            directory_dialog(basedir)
+
         dir_button = QtWidgets.QPushButton(_('Select directory'))
-        dir_button.clicked.connect(directory_dialog)
+        dir_button.clicked.connect(directory_dialog_basedir)
 
         lay_dir = QtWidgets.QHBoxLayout()
         lay_dir.addWidget(basedir)
         lay_dir.addWidget(dir_button)
 
+        def directory_dialog_single():
+            directory_dialog(basedir_single)
+
+        dir_button_single = QtWidgets.QPushButton(_('Select directory'))
+        dir_button_single.clicked.connect(directory_dialog_single)
+
+        lay_dir_single = QtWidgets.QHBoxLayout()
+        lay_dir_single.addWidget(basedir_single)
+        lay_dir_single.addWidget(dir_button_single)
+
         layout = QtWidgets.QFormLayout()
         layout.addRow(_('Output directory (strftime possible):'), lay_dir)
         layout.addRow(_('Basename of files (strftime possible):'), basename)
         layout.addRow(_('Keep single shots:'), keep_pictures)
+        layout.addRow(_('Store single shots in different directory:'), single_extra)
+        layout.addRow(_('Directory for single shots (strftime possible):'), lay_dir_single)
 
         widget = QtWidgets.QWidget()
         widget.setLayout(layout)
@@ -1022,6 +1044,10 @@ class Settings(QtWidgets.QFrame):
                       self.get('Storage', 'basename').text())
         self._cfg.set('Storage', 'keep_pictures',
                       str(self.get('Storage', 'keep_pictures').isChecked()))
+        self._cfg.set('Storage', 'single_extra',
+                      str(self.get('Storage', 'single_extra').isChecked()))
+        self._cfg.set('Storage', 'basedir_single',
+                      self.get('Storage', 'basedir_single').text())
 
         self._cfg.set('Gpio', 'enable',
                       str(self.get('Gpio', 'enable').isChecked()))

--- a/photobooth/worker/__init__.py
+++ b/photobooth/worker/__init__.py
@@ -43,8 +43,13 @@ class Worker:
         self._pic_list = PictureList(basename)
 
         # Picture list for individual shots
-        path = os.path.join(config.get('Storage', 'basedir'),
-                            config.get('Storage', 'basename') + '_shot_')
+        single_extra = config.getBool('Storage', 'single_extra')
+        if single_extra:
+            path = os.path.join(config.get('Storage', 'basedir_single'),
+                                config.get('Storage', 'basename') + '_shot_')
+        else:
+            path = os.path.join(config.get('Storage', 'basedir'),
+                                config.get('Storage', 'basename') + '_shot_')
         basename = strftime(path, localtime())
         self._shot_list = PictureList(basename)
 


### PR DESCRIPTION
This PR allows single shots to be stored in a different directory. If the feature is enabled an extra path that is configured in the settings will be used. If it is disabled (the default) the old behavior will stay.

Fixes #155.