### PR TITLE
retry image capture on error, allow configuration

### DIFF
--- a/photobooth/camera/__init__.py
+++ b/photobooth/camera/__init__.py
@@ -138,10 +138,23 @@ class Camera:
                 self._comm.send(Workers.GUI,
                                 StateMachine.CameraEvent('preview', byte_data))
 
+    def _getPicture(self):
+        tries = 0
+        max_retries = self._cfg.getInt('Photobooth', 'capture_error_retry')
+        while True:
+            try:
+                return self._cap.getPicture()
+            except BaseException as e:
+                if tries < max_retries:
+                    logging.warn(('CameraGphoto2: Error on capture #{} ErrorCode: {}').format(tries, str(e)))
+                    tries += 1
+                else:
+                    raise e
+
     def capturePicture(self, state):
 
         self.setIdle()
-        picture = self._cap.getPicture()
+        picture = self._getPicture()
         if self._rotation is not None:
             picture = picture.transpose(self._rotation)
         byte_data = BytesIO()

--- a/photobooth/defaults.cfg
+++ b/photobooth/defaults.cfg
@@ -62,6 +62,8 @@ display_time = 5
 postprocess_time = 60
 # Overwrite displayed error message (Leave empty for none)
 overwrite_error_message =
+# Number of retries on capture error
+capture_error_retry = 0
 
 [Picture]
 # Number of pictures in horizontal direction

--- a/photobooth/gui/Qt5Gui/Frames.py
+++ b/photobooth/gui/Qt5Gui/Frames.py
@@ -595,6 +595,12 @@ class Settings(QtWidgets.QFrame):
             self._cfg.get('Photobooth', 'overwrite_error_message'))
         self.add('Photobooth', 'overwrite_error_message', err_msg)
 
+        capture_retry = QtWidgets.QSpinBox()
+        capture_retry.setRange(0,10)
+        capture_retry.setValue(self._cfg.getInt('Photobooth',
+                                                'capture_error_retry'))
+        self.add('Photobooth', 'capture_error_retry', capture_retry)
+
         layout = QtWidgets.QFormLayout()
         layout.addRow(_('Show preview during countdown:'), preview)
         layout.addRow(_('Greeter time before countdown [s]:'), greet_time)
@@ -602,6 +608,7 @@ class Settings(QtWidgets.QFrame):
         layout.addRow(_('Picture display time [s]:'), displ_time)
         layout.addRow(_('Postprocess timeout [s]:'), postproc_time)
         layout.addRow(_('Overwrite displayed error message:'), err_msg)
+        layout.addRow(_('Retries on capture error:'), capture_retry)
 
         widget = QtWidgets.QWidget()
         widget.setLayout(layout)
@@ -991,6 +998,8 @@ class Settings(QtWidgets.QFrame):
                       str(self.get('Photobooth', 'postprocess_time').text()))
         self._cfg.set('Photobooth', 'overwrite_error_message',
                       self.get('Photobooth', 'overwrite_error_message').text())
+        self._cfg.set('Photobooth', 'capture_error_retry',
+                      self.get('Photobooth', 'capture_error_retry').text())
 
         self._cfg.set('Camera', 'module',
                       camera.modules[self.get('Camera',


### PR DESCRIPTION
Allows the camera to try capturing a photo multiple times before showing the error message. The retry counter is configurable. 
Should fix #167 